### PR TITLE
Add Docker initial setup page

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,6 +37,9 @@ LOG = os.path.join(APP, 'app.log')
 CSV = os.path.join(APP, 'reservations.csv')
 VLOG = os.path.join(APP, 'voucher_log.csv')
 
+RUNNING_DOCKER = os.path.exists('/.dockerenv') or os.environ.get('RUN_IN_DOCKER')
+DOCKER_INIT_FLAG = os.path.join(APP, '.docker_initialized')
+
 TPL = os.path.join(APP, 'templates')
 STA = os.path.join(APP, 'static')
 LOGOS = os.path.join(STA, 'logos')
@@ -336,6 +339,14 @@ def log_voucher(success, code='', method='', email='', first='', last='', phone=
             ''
         ])
 
+# ───────────────────────── Docker first-run redirect ─────────────---
+@app.before_request
+def docker_setup_redirect():
+    if RUNNING_DOCKER and not os.path.exists(DOCKER_INIT_FLAG):
+        allowed = {'docker_setup', 'static', 'favicon', 'logo'}
+        if request.endpoint not in allowed:
+            return redirect(url_for('docker_setup'))
+
 # ───────────────────────── SMTP helper ─────────────────────────────--
 def send_email(to_addr, subject, body):
     stg = load_stg()
@@ -618,6 +629,30 @@ def terms():
     lang = session.get('lang', stg.get('default_language', 'en'))
     return render_template('terms.html',
                            settings=stg, config=load_cfg(), lang=lang)
+
+# ───────────────────────── Docker first boot setup ───────────────────
+@app.route('/docker_setup', methods=['GET','POST'])
+def docker_setup():
+    if not RUNNING_DOCKER:
+        abort(404)
+    if os.path.exists(DOCKER_INIT_FLAG):
+        return redirect(url_for('index'))
+    if request.method == 'POST':
+        ips = request.form.get('whitelisted_ips', '').strip()
+        pin = request.form.get('pin', '').strip()
+        if not ips:
+            flash('Please enter at least one IP', 'danger')
+        elif not re.fullmatch(r"\d{4}", pin):
+            flash('PIN must be 4 digits', 'danger')
+        else:
+            cfg = load_cfg()
+            cfg['General']['whitelisted_ips'] = ips
+            cfg['General']['pin_code'] = pin
+            save_cfg(cfg)
+            open(DOCKER_INIT_FLAG, 'w').write('done')
+            flash('Configuration saved', 'success')
+            return redirect(url_for('index'))
+    return render_template('docker_setup.html', settings=load_stg(), config=load_cfg())
 
 # ───────────────────────── Guest index page ──────────────────────────
 @app.route('/', methods=['GET','POST'])

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ UniFi Voucher Portal – single-file Flask application
 """
 APP_VERSION = "1.0.5"
 
-import os, sys, json, csv, re, subprocess, configparser, logging
+import os, sys, json, csv, re, subprocess, configparser, logging, ipaddress
 from datetime import datetime, timedelta
 from functools import wraps
 from logging.handlers import RotatingFileHandler
@@ -637,13 +637,26 @@ def docker_setup():
         abort(404)
     if os.path.exists(DOCKER_INIT_FLAG):
         return redirect(url_for('index'))
+    ips = ''
+    pin = ''
+    force = request.form.get('force')
     if request.method == 'POST':
         ips = request.form.get('whitelisted_ips', '').strip()
         pin = request.form.get('pin', '').strip()
+        invalid = []
+        if ips:
+            for item in [i.strip() for i in ips.split(',') if i.strip()]:
+                try:
+                    ipaddress.ip_address(item)
+                except ValueError:
+                    invalid.append(item)
         if not ips:
             flash('Please enter at least one IP', 'danger')
         elif not re.fullmatch(r"\d{4}", pin):
             flash('PIN must be 4 digits', 'danger')
+        elif invalid and not force:
+            flash('Some IPs seem invalid: ' + ', '.join(invalid) + '. Submit again to confirm anyway.', 'warning')
+            force = '1'
         else:
             cfg = load_cfg()
             cfg['General']['whitelisted_ips'] = ips
@@ -652,7 +665,9 @@ def docker_setup():
             open(DOCKER_INIT_FLAG, 'w').write('done')
             flash('Configuration saved', 'success')
             return redirect(url_for('index'))
-    return render_template('docker_setup.html', settings=load_stg(), config=load_cfg())
+    countdown = 45 if not force else 0
+    return render_template('docker_setup.html', settings=load_stg(), config=load_cfg(),
+                           ips=ips, pin=pin, force=force, countdown=countdown)
 
 # ───────────────────────── Guest index page ──────────────────────────
 @app.route('/', methods=['GET','POST'])

--- a/templates/docker_setup.html
+++ b/templates/docker_setup.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+<main class="pin-card">
+  <h2>Docker Initial Setup</h2>
+  <p>These settings are final in this Docker version.</p>
+  <form method="POST">
+    <label>Whitelisted IPs (comma separated)
+      <input type="text" name="whitelisted_ips" required>
+    </label>
+    <label>Admin PIN (4 digits)
+      <input type="password" name="pin" pattern="\d{4}" required>
+    </label>
+    <div class="submit-container">
+      <button type="submit" id="confirm" disabled>Confirm (5)</button>
+    </div>
+  </form>
+</main>
+<script>
+let s=5,btn=document.getElementById('confirm');
+function tick(){
+  s--;if(s<=0){btn.disabled=false;btn.textContent='Confirm';}
+  else{btn.textContent='Confirm ('+s+')';setTimeout(tick,1000);} }
+setTimeout(tick,1000);
+</script>
+{% endblock %}

--- a/templates/docker_setup.html
+++ b/templates/docker_setup.html
@@ -4,22 +4,24 @@
   <h2>Docker Initial Setup</h2>
   <p>These settings are final in this Docker version.</p>
   <form method="POST">
+    <input type="hidden" name="force" value="{{ force or '' }}">
     <label>Whitelisted IPs (comma separated)
-      <input type="text" name="whitelisted_ips" required>
+      <input type="text" name="whitelisted_ips" placeholder="e.g. 192.168.1.100, 2001:db8::1" value="{{ ips|default('') }}" required>
     </label>
     <label>Admin PIN (4 digits)
-      <input type="password" name="pin" pattern="\d{4}" required>
+      <input type="password" name="pin" pattern="\d{4}" placeholder="e.g. 1234" value="{{ pin|default('') }}" required>
     </label>
     <div class="submit-container">
-      <button type="submit" id="confirm" disabled>Confirm (5)</button>
+      <button type="submit" id="confirm" disabled>Confirm ({{ countdown }})</button>
     </div>
   </form>
 </main>
 <script>
-let s=5,btn=document.getElementById('confirm');
+let s={{ countdown }};
+const btn=document.getElementById('confirm');
 function tick(){
-  s--;if(s<=0){btn.disabled=false;btn.textContent='Confirm';}
-  else{btn.textContent='Confirm ('+s+')';setTimeout(tick,1000);} }
-setTimeout(tick,1000);
+  if(s<=0){btn.disabled=false;btn.textContent='Confirm';}
+  else{btn.textContent='Confirm ('+s+')';s--;setTimeout(tick,1000);} }
+tick();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- detect Docker environment and run first-boot setup
- redirect to setup page until completed
- write whitelist IPs and admin PIN to `config.ini`
- template for Docker setup page with countdown

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68664ce8f9e88320848cf6c8fda12d0c