### PR TITLE
Improve Docker setup usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# UniFi Network Voucher Manager
+# UniFi Network Voucher Manager - DOCKER Version
 
 A single-file Flask application that issues UniFi guest WiFi vouchers. Users request a code from a self-service portal while administrators configure options through a PIN-protected page. The application aims to be easy to deploy on a small server or appliance.
 
@@ -112,6 +112,26 @@ See the following example in the ToU:
 9. Done !
 
 ---
+
+## Docker Deployment
+
+The application automatically detects when it runs inside a Docker container. On
+the very first start it shows a short form asking for the IP addresses allowed
+to access the admin section and for a 4‑digit PIN code. Once confirmed, these
+values are written to `config.ini` and the setup screen will not appear again.
+
+1. Build or obtain a Docker image containing this repository.
+2. Run the container and expose port `8080`:
+
+   ```bash
+   docker run -d -p 8080:8080 --name unifi-vm -v "%cd%\config.ini:/app/config.ini" -v "%cd%\settings.json:/app/settings.json" unifi-voucher-manager
+   ```
+
+   Mount the project directory as a volume if you wish to persist configuration
+   and log files across restarts.
+
+3. Browse to `http://<host>:8080` to complete the one‑time Docker setup. After
+   that, the admin portal is reachable at `/admin/pin` from a whitelisted IP.
 
 ## Configuration
 

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ UniFi Voucher Portal – single-file Flask application
 """
 APP_VERSION = "1.0.5"
 
-import os, sys, json, csv, re, subprocess, configparser, logging
+import os, sys, json, csv, re, subprocess, configparser, logging, ipaddress
 from datetime import datetime, timedelta
 from functools import wraps
 from logging.handlers import RotatingFileHandler
@@ -36,6 +36,9 @@ STG = os.path.join(APP, 'settings.json')
 LOG = os.path.join(APP, 'app.log')
 CSV = os.path.join(APP, 'reservations.csv')
 VLOG = os.path.join(APP, 'voucher_log.csv')
+
+RUNNING_DOCKER = os.path.exists('/.dockerenv') or os.environ.get('RUN_IN_DOCKER')
+DOCKER_INIT_FLAG = os.path.join(APP, '.docker_initialized')
 
 TPL = os.path.join(APP, 'templates')
 STA = os.path.join(APP, 'static')
@@ -255,10 +258,13 @@ def inject_globals():
 
 # ───────────────────────── Rate limiter ──────────────────────────────
 def _mk_limiter(stg):
-    lim = Limiter(get_remote_address, app=app,
-        default_limits=[f"{stg['rate_limit_per_minute']} per {stg['rate_limit_scope_minutes']} minute"],
-        storage_uri="memory://")
-    return lim
+    per = int(stg.get('rate_limit_per_minute', 0))
+    mins = int(stg.get('rate_limit_scope_minutes', 1) or 1)
+    enabled = per > 0
+    limits = [f"{per} per {mins} minute"] if enabled else []
+    return Limiter(get_remote_address, app=app,
+                   default_limits=limits, storage_uri="memory://",
+                   enabled=enabled)
 
 limiter = _mk_limiter(load_stg())
 
@@ -271,12 +277,17 @@ def periodic_cleanup():
         LAST_CLEANUP = datetime.now()
 
 def update_rate_limits(stg):
-    per = max(int(stg.get('rate_limit_per_minute', 1)), 1)
-    mins = max(int(stg.get('rate_limit_scope_minutes', 1)), 1)
-    rule = f"{per} per {mins} minute"
-    limiter.limit_manager.set_default_limits([
-        LimitGroup(rule, get_remote_address)
-    ])
+    per = int(stg.get('rate_limit_per_minute', 0))
+    mins = int(stg.get('rate_limit_scope_minutes', 1) or 1)
+    enabled = per > 0
+    limiter.enabled = enabled
+    if enabled:
+        rule = f"{per} per {mins} minute"
+        limiter.limit_manager.set_default_limits([
+            LimitGroup(rule, get_remote_address)
+        ])
+    else:
+        limiter.limit_manager.set_default_limits([])
 
 # ───────────────────────── Utils ─────────────────────────────────────
 ip = lambda: request.headers.get('X-Forwarded-For', request.remote_addr)
@@ -301,7 +312,24 @@ def mac_addr():
         if val:
             return val
     return mac_from_unifi()
-whitelisted = lambda: ip() in [x.strip() for x in load_cfg().get('General','whitelisted_ips').split(',')]
+
+def whitelisted():
+    client = ip()
+    try:
+        client_ip = ipaddress.ip_address(client)
+    except ValueError:
+        return False
+    entries = [x.strip() for x in load_cfg().get('General', 'whitelisted_ips', fallback='').split(',')]
+    for e in entries:
+        if not e:
+            continue
+        try:
+            if client_ip in ipaddress.ip_network(e, strict=False):
+                return True
+        except ValueError:
+            continue
+    return False
+
 limiter.request_filter(whitelisted)
 
 @app.after_request
@@ -335,6 +363,14 @@ def log_voucher(success, code='', method='', email='', first='', last='', phone=
             reservation_id,
             ''
         ])
+
+# ───────────────────────── Docker first-run redirect ─────────────---
+@app.before_request
+def docker_setup_redirect():
+    if RUNNING_DOCKER and not os.path.exists(DOCKER_INIT_FLAG):
+        allowed = {'docker_setup', 'static', 'favicon', 'logo'}
+        if request.endpoint not in allowed:
+            return redirect(url_for('docker_setup'))
 
 # ───────────────────────── SMTP helper ─────────────────────────────--
 def send_email(to_addr, subject, body):
@@ -618,6 +654,47 @@ def terms():
     lang = session.get('lang', stg.get('default_language', 'en'))
     return render_template('terms.html',
                            settings=stg, config=load_cfg(), lang=lang)
+
+# ───────────────────────── Docker first boot setup ───────────────────
+@app.route('/docker_setup', methods=['GET','POST'])
+def docker_setup():
+    if not RUNNING_DOCKER:
+        abort(404)
+    if os.path.exists(DOCKER_INIT_FLAG):
+        return redirect(url_for('index'))
+    ips = ''
+    pin = ''
+    client_ip = ip()
+    force = request.form.get('force')
+    if request.method == 'POST':
+        ips = request.form.get('whitelisted_ips', '').strip()
+        pin = request.form.get('pin', '').strip()
+        invalid = []
+        if ips:
+            for item in [i.strip() for i in ips.split(',') if i.strip()]:
+                try:
+                    ipaddress.ip_address(item)
+                except ValueError:
+                    invalid.append(item)
+        if not ips:
+            flash('Please enter at least one IP', 'danger')
+        elif not re.fullmatch(r"\d{4}", pin):
+            flash('PIN must be 4 digits', 'danger')
+        elif invalid and not force:
+            flash('Some IPs seem invalid: ' + ', '.join(invalid) + '. Submit again to confirm anyway.', 'warning')
+            force = '1'
+        else:
+            cfg = load_cfg()
+            cfg['General']['whitelisted_ips'] = ips
+            cfg['General']['pin_code'] = pin
+            save_cfg(cfg)
+            open(DOCKER_INIT_FLAG, 'w').write('done')
+            flash('Configuration saved', 'success')
+            return redirect(url_for('index'))
+    countdown = 45 if not force else 0
+    return render_template('docker_setup.html', settings=load_stg(), config=load_cfg(),
+                           ips=ips, pin=pin, force=force, countdown=countdown,
+                           client_ip=client_ip)
 
 # ───────────────────────── Guest index page ──────────────────────────
 @app.route('/', methods=['GET','POST'])

--- a/templates/docker_setup.html
+++ b/templates/docker_setup.html
@@ -1,0 +1,41 @@
+{% extends "base.html" %}
+{% block content %}
+<main class="pin-card">
+  <h2>Docker Initial Setup</h2>
+  <p>These settings are final in this Docker version.</p>
+  <p>Your current IP is {{ client_ip }}.</p>
+  <form method="POST">
+    <input type="hidden" name="force" value="{{ force or '' }}">
+    <label>Whitelisted IPs (comma separated)
+      <input type="text" name="whitelisted_ips" placeholder="e.g. 192.168.1.100, 2001:db8::1" value="{{ ips|default('') }}" required>
+      <button type="button" id="add-my-ip" data-ip="{{ client_ip }}">Add my IP ({{ client_ip }})</button>
+    </label>
+    <label>Admin PIN (4 digits)
+      <input type="password" name="pin" pattern="\d{4}" placeholder="e.g. 1234" value="{{ pin|default('') }}" required>
+    </label>
+    <div class="submit-container">
+      <button type="submit" id="confirm" disabled>Confirm ({{ countdown }})</button>
+    </div>
+  </form>
+</main>
+<script>
+let s={{ countdown }};
+const btn=document.getElementById('confirm');
+function tick(){
+  if(s<=0){btn.disabled=false;btn.textContent='Confirm';}
+  else{btn.textContent='Confirm ('+s+')';s--;setTimeout(tick,1000);} }
+tick();
+const btnIp=document.getElementById('add-my-ip');
+if(btnIp){
+  btnIp.addEventListener('click',()=>{
+    const field=document.querySelector('input[name="whitelisted_ips"]');
+    const ip=btnIp.dataset.ip;
+    const items=field.value.split(',').map(i=>i.trim()).filter(Boolean);
+    if(!items.includes(ip)){
+      items.push(ip);
+      field.value=items.join(', ');
+    }
+  });
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- disable rate limiter when rate_limit_per_minute is 0
- rework IP whitelist logic and expose client's IP on setup page
- add button to insert current IP during Docker first-run setup

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68664ce8f9e88320848cf6c8fda12d0c